### PR TITLE
Update README with correct repository links 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A feature-rich Oh My Posh theme optimized for C# developers and multi-language d
 1. **Download the theme file**:
    ```powershell
    # Download to your Oh My Posh themes directory
-   Invoke-WebRequest -Uri "https://raw.githubusercontent.com/gordug/posh-1/main/solarized_dark.omp.json" -OutFile "~/.poshthemes/solarized_dark_enhanced.omp.json"
+   Invoke-WebRequest -Uri "https://raw.githubusercontent.com/gordug/posh/main/solarized_dark.omp.json" -OutFile "~/.poshthemes/solarized_dark_enhanced.omp.json"
    ```
 
 2. **Apply the theme**:
@@ -64,8 +64,8 @@ A feature-rich Oh My Posh theme optimized for C# developers and multi-language d
 
 1. **Clone this repository**:
    ```powershell
-   git clone https://github.com/gordug/posh-1.git
-   cd posh-1
+   git clone https://github.com/gordug/posh.git
+   cd posh
    ```
 
 2. **Copy theme to Oh My Posh directory**:
@@ -303,8 +303,8 @@ $env:POSHLOG_LEVEL = "debug"
 
 ```powershell
 # Clone and setup
-git clone https://github.com/gordug/posh-1.git
-cd posh-1
+git clone https://github.com/gordug/posh.git
+cd posh
 
 # Install development dependencies
 # (Oh My Posh and PowerShell 7+ required)
@@ -344,8 +344,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 📞 Support
 
-- **Issues**: [GitHub Issues](https://github.com/gordug/posh-1/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/gordug/posh-1/discussions)
+- **Issues**: [GitHub Issues](https://github.com/gordug/posh/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/gordug/posh/discussions)
 - **Documentation**: [Oh My Posh Docs](https://ohmyposh.dev/docs/)
 
 ---


### PR DESCRIPTION
This pull request updates the repository references in the `README.md` file to reflect a corrected GitHub repository URL. The changes ensure consistency and accuracy for users when cloning the repository, downloading theme files, or accessing support resources.

### Repository URL Updates:

* Updated the `Invoke-WebRequest` command to use the correct GitHub repository URL in the theme download instructions. (`README.md`, [README.mdL55-R55](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R55))
* Corrected the `git clone` command and directory navigation instructions to point to the correct repository. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R68) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L306-R307)
* Updated support links for **Issues** and **Discussions** to use the correct repository URL. (`README.md`, [README.mdL347-R348](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L347-R348))